### PR TITLE
fixed urls to use namespace used in views

### DIFF
--- a/djangosaml2idp/urls.py
+++ b/djangosaml2idp/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 from . import views
 
+app_name = 'djangosaml2idp'
 urlpatterns = [
     path('sso/post', views.sso_entry, name="saml_login_post"),
     path('sso/redirect', views.sso_entry, name="saml_login_redirect"),


### PR DESCRIPTION
sso_entry in views calls reverse('djangosaml2idp:saml_login_process')

This causes an exception as urls isn't using djangosaml2idp namespace