### PR TITLE
Fixed the example idp and sp projects so that other users can run them straight away, with some basic improvements

### DIFF
--- a/example_setup/idp/idp/saml2_config/sp_metadata.xml
+++ b/example_setup/idp/idp/saml2_config/sp_metadata.xml
@@ -1,7 +1,7 @@
 <md:EntityDescriptor 
     xmlns:ds="http://www.w3.org/2000/09/xmldsig#" 
     xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" 
-    xmlns:ns1="urn:oasis:names:tc:SAML:metadata:algsupport" entityID="http://localhost:8000/saml2/metadata/" validUntil="2018-04-07T12:21:43Z">
+    xmlns:ns1="urn:oasis:names:tc:SAML:metadata:algsupport" entityID="http://localhost:8000/saml2/metadata/" validUntil="2019-04-07T12:21:43Z">
     <md:Extensions>
         <ns1:DigestMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#md5"/>
         <ns1:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#ripemd160"/>

--- a/example_setup/idp/idp/settings.py
+++ b/example_setup/idp/idp/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'w1#&b@*haty+1pmlw--ll9i!5z+d$e*5yxq0&cgo16e_vhd7r('
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition
@@ -120,6 +120,10 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.10/howto/static-files/
 
 STATIC_URL = '/static/'
+
+STATICFILES_DIRS = ( 
+      BASE_DIR + '/static/',  
+)
 
 ### Everything above are default settings made by django-admin startproject
 ### The following is added for djangosaml2idp IdP configuration.

--- a/example_setup/idp/idp/urls.py
+++ b/example_setup/idp/idp/urls.py
@@ -1,11 +1,15 @@
 from django.urls import include, path
 from django.contrib import admin
 from django.contrib.auth.views import login
+from django.conf import settings
+from django.conf.urls.static import static
 
 import djangosaml2idp
 
+app_name = 'example_idp'
 urlpatterns = [
     #path('idp/', include('djangosaml2idp.urls')),
-    path('idp/', include('djangosaml2idp.urls')),
+    path('idp/', include('djangosaml2idp.urls', namespace='djangosaml2')),
     path('login/', login, {'template_name': 'idp/login.html'}, name='login'),
-]
+    path('admin/', admin.site.urls),
+] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/example_setup/sp/sp/saml2_config/idp_metadata.xml
+++ b/example_setup/sp/sp/saml2_config/idp_metadata.xml
@@ -1,7 +1,7 @@
 <ns0:EntityDescriptor 
     xmlns:ns0="urn:oasis:names:tc:SAML:2.0:metadata" 
     xmlns:ns1="urn:oasis:names:tc:SAML:metadata:algsupport" 
-    xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" entityID="http://localhost:9000/idp/metadata" validUntil="2018-04-07T12:21:20Z">
+    xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" entityID="http://localhost:9000/idp/metadata" validUntil="2019-04-07T12:21:20Z">
     <ns0:Extensions>
         <ns1:DigestMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#md5"/>
         <ns1:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#ripemd160"/>

--- a/example_setup/sp/sp/settings.py
+++ b/example_setup/sp/sp/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'ar249h_c(@5#x)ha_vou=4%plz*#!*l=+4c^jbo6wi%8z222hg'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition

--- a/example_setup/sp/sp/urls.py
+++ b/example_setup/sp/sp/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.conf.urls import include, path
 from django.contrib import admin
 from django.contrib.auth.views import logout
 


### PR DESCRIPTION
Changes include:
Example sp:
Set allowed hosts * in settings.py (to enable testing from a remote machine)
fixed import of url instead of path in urls.py (fixed an import error)
Extended validUntil on idp_metadata.xml (validUntil date had passed)

Changes to example idp:

Set allowed hosts * (to enable testing from a remote machine)
Use namespaced url (not strictly required due previous app_name change, but explicit is better than implicit)
Enabled admin and static files (for easy user management and customisation)
Extended validUntil on sp_metadata.xml (validUntil date had passed)